### PR TITLE
Added password option for up command

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"os"
-
 	"path/filepath"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -38,6 +38,14 @@ var upCmd = &cobra.Command{
 		}
 		logger.Info("identity file = %s", identityFile)
 
+		password, err := cmd.Flags().GetString("password")
+		if err != nil {
+			return err
+		}
+		if password != "" {
+			logger.Info("password = %s", strings.Repeat("x", len(password))) // Do not display the password.
+		}
+
 		pwd, err := os.Getwd()
 		if err != nil {
 			return err
@@ -48,7 +56,7 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
-		authProvider = helper.NewAuthProvider(filepath.Join(homeDir, ".ssh", identityFile))
+		authProvider = helper.NewAuthProvider(filepath.Join(homeDir, ".ssh", identityFile), password)
 		updateService := service.NewSync(authProvider, homeDir, pwd, pwd)
 		return updateService.Resolve(isForceUpdate)
 	},
@@ -57,4 +65,5 @@ var upCmd = &cobra.Command{
 func initDepCmd() {
 	upCmd.PersistentFlags().BoolP("force", "f", false, "update locked file and .proto vendors")
 	upCmd.PersistentFlags().StringP("identity-file", "i", "id_rsa", "set the identity file for SSH")
+	upCmd.PersistentFlags().StringP("password", "p", "", "set the password for SSH")
 }

--- a/helper/auth.go
+++ b/helper/auth.go
@@ -14,17 +14,19 @@ type AuthProvider interface {
 }
 
 type AuthProviderWithSSH struct {
-	pemFile string
+	pemFile  string
+	password string
 }
 
 type AuthProviderHTTPS struct {
 }
 
-func NewAuthProvider(pemFile string) AuthProvider {
+func NewAuthProvider(pemFile, password string) AuthProvider {
 	if pemFile != "" {
 		logger.Info("use SSH protocol")
 		return &AuthProviderWithSSH{
-			pemFile: pemFile,
+			pemFile:  pemFile,
+			password: password,
 		}
 	} else {
 		logger.Info("use HTTP/HTTPS protocol")
@@ -41,7 +43,7 @@ func (p *AuthProviderWithSSH) GetRepositoryURL(reponame string) string {
 }
 
 func (p *AuthProviderWithSSH) AuthMethod() transport.AuthMethod {
-	am, err := ssh.NewPublicKeysFromFile("git", p.pemFile, "")
+	am, err := ssh.NewPublicKeysFromFile("git", p.pemFile, p.password)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Support for ssh key with password.

## Why
Using an SSH key with password causes an error.
```
$ protodep up
[INFO] force update = false
[INFO] identity file = id_rsa
[INFO] use SSH protocol
[INFO] Getting github.com/suzujun/example panic: x509: decryption password incorrect

goroutine 1 [running]:
github.com/suzujun/protodep/helper.(*AuthProviderWithSSH).AuthMethod(0xc420117c40, 0x44, 0xc4201229f0)
        /Users/suzujun/_go/src/github.com/suzujun/protodep/helper/auth.go:48 +0xc7
github.com/suzujun/protodep/repository.(*GitHubRepository).Open(0xc420073360, 0xc420073360, 0x2, 0xc42012e1c0)
        /Users/suzujun/_go/src/github.com/suzujun/protodep/repository/git.go:65 +0x1242
github.com/suzujun/protodep/service.(*SyncImpl).Resolve(0xc42007dcc0, 0xc42007dc00, 0x0, 0x0)
        /Users/suzujun/_go/src/github.com/suzujun/protodep/service/sync.go:52 +0x340
github.com/suzujun/protodep/cmd.glob..func1(0x17b9f00, 0x17d9ad0, 0x0, 0x0, 0x0, 0x0)
        /Users/suzujun/_go/src/github.com/suzujun/protodep/cmd/up.go:59 +0x4d9
github.com/spf13/cobra.(*Command).execute(0x17b9f00, 0x17d9ad0, 0x0, 0x0, 0x17b9f00, 0x17d9ad0)
        /Users/suzujun/_go/src/github.com/spf13/cobra/command.go:649 +0x457
github.com/spf13/cobra.(*Command).ExecuteC(0x17b9cc0, 0x1, 0x0, 0x0)
        /Users/suzujun/_go/src/github.com/spf13/cobra/command.go:728 +0x339
github.com/spf13/cobra.(*Command).Execute(0x17b9cc0, 0x0, 0x1563e20)
        /Users/suzujun/_go/src/github.com/spf13/cobra/command.go:687 +0x2b
github.com/suzujun/protodep/cmd.Execute()
        /Users/suzujun/_go/src/github.com/suzujun/protodep/cmd/root.go:37 +0x31
main.main()
        /Users/suzujun/_go/src/github.com/suzujun/protodep/main.go:6 +0x20
exit status 2
```

## test
- [x] none-password ssh-key for up command
- [x] using password ssh-key for up command
 