### PR TITLE
Changed output path

### DIFF
--- a/service/sync.go
+++ b/service/sync.go
@@ -54,7 +54,7 @@ func (s *SyncImpl) Resolve(forceUpdate bool) error {
 			return err
 		}
 
-		outdir := filepath.Join(s.outputRootDir, protodep.ProtoOutdir, dep.Repository())
+		outdir := filepath.Join(s.outputRootDir, protodep.ProtoOutdir)
 
 		sources := make([]protoResource, 0)
 


### PR DESCRIPTION
Removed repository path of output path and changed to root.
Because it conforms to google specifications.

For example, reading the next proto file using the current protodep may destroy the import path.
https://github.com/google/protobuf/blob/master/src/google/protobuf/api.proto#L35-L36

The proto file to be read must match the proto package name and the file hierarchy.