### PR TITLE
delete root directory only once

### DIFF
--- a/service/protodep.toml
+++ b/service/protodep.toml
@@ -3,3 +3,6 @@ proto_outdir = "./proto"
 [[dependencies]]
   target = "github.com/openfresh/plasma/protobuf"
   branch = "master"
+[[dependencies]]
+  target = "github.com/google/protobuf/src"
+  branch = "master"

--- a/service/sync.go
+++ b/service/sync.go
@@ -1,13 +1,14 @@
 package service
 
 import (
-	"github.com/stormcat24/protodep/helper"
-	"strings"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+
 	"github.com/stormcat24/protodep/dependency"
+	"github.com/stormcat24/protodep/helper"
 	"github.com/stormcat24/protodep/repository"
-	"io/ioutil"
 )
 
 type protoResource struct {
@@ -46,6 +47,11 @@ func (s *SyncImpl) Resolve(forceUpdate bool) error {
 	newdeps := make([]dependency.ProtoDepDependency, 0, len(protodep.Dependencies))
 	protodepDir := filepath.Join(s.userHomeDir, ".protodep")
 
+	outdir := filepath.Join(s.outputRootDir, protodep.ProtoOutdir)
+	if err := os.RemoveAll(outdir); err != nil {
+		return err
+	}
+
 	for _, dep := range protodep.Dependencies {
 		gitrepo := repository.NewGitRepository(protodepDir, dep, s.authProvider)
 
@@ -53,8 +59,6 @@ func (s *SyncImpl) Resolve(forceUpdate bool) error {
 		if err != nil {
 			return err
 		}
-
-		outdir := filepath.Join(s.outputRootDir, protodep.ProtoOutdir)
 
 		sources := make([]protoResource, 0)
 
@@ -71,10 +75,6 @@ func (s *SyncImpl) Resolve(forceUpdate bool) error {
 			}
 			return nil
 		})
-
-		if err := os.RemoveAll(outdir); err != nil {
-			return err
-		}
 
 		for _, s := range sources {
 			outpath := filepath.Join(outdir, s.relativeDest)

--- a/service/sync_test.go
+++ b/service/sync_test.go
@@ -1,13 +1,14 @@
 package service
 
 import (
-	"testing"
-	"github.com/golang/mock/gomock"
-	"github.com/stormcat24/protodep/helper"
-	"github.com/mitchellh/go-homedir"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/mitchellh/go-homedir"
+	"github.com/stormcat24/protodep/helper"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSync(t *testing.T) {
@@ -24,7 +25,9 @@ func TestSync(t *testing.T) {
 
 	authProviderMock := helper.NewMockAuthProvider(c)
 	authProviderMock.EXPECT().AuthMethod().Return(nil).AnyTimes()
-	authProviderMock.EXPECT().GetRepositoryURL(gomock.Any()).Return("https://github.com/openfresh/plasma.git").AnyTimes()
+	authProviderMock.EXPECT().GetRepositoryURL(gomock.Any()).Return("https://github.com/google/protobuf.git").After(
+		authProviderMock.EXPECT().GetRepositoryURL(gomock.Any()).Return("https://github.com/openfresh/plasma.git"),
+	)
 
 	pwd, err := os.Getwd()
 	require.NoError(t, err)
@@ -36,8 +39,19 @@ func TestSync(t *testing.T) {
 	err = target.Resolve(false)
 	require.NoError(t, err)
 
+	if !isFileExist(filepath.Join(outputRootDir, "proto/stream.proto")) {
+		t.Error("not found file [stream.proto]")
+	}
+	if !isFileExist(filepath.Join(outputRootDir, "proto/google/protobuf/empty.proto")) {
+		t.Error("not found file [empty.proto]")
+	}
 
 	// fetch
 	err = target.Resolve(false)
 	require.NoError(t, err)
+}
+
+func isFileExist(path string) bool {
+	_, err := os.Stat(path)
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
Fixed a problem that the root directory is erased every time whenever repository is imported.
(I'm sorry, I included a bug in my previous pull request https://github.com/stormcat24/protodep/pull/19)