### PR TITLE
add SSH agent support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,12 +25,6 @@ import (
 var RootCmd = &cobra.Command{
 	Use:   "protodep",
 	Short: "Manage vendor for Protocol Buffer IDL file (.proto)",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
 }
 
 func Execute() {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -62,15 +62,19 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
-		identifyPath := filepath.Join(homeDir, ".ssh", identityFile)
-		isSSH, err := helper.IsAvailableSSH(identifyPath)
-		if err != nil {
-			return err
-		}
-		if isSSH {
-			authProvider = helper.NewAuthProvider(identifyPath, password)
+		if identityFile == "" && password == "" {
+			authProvider = helper.NewAuthProvider()
 		} else {
-			authProvider = helper.NewAuthProvider("", "")
+			identifyPath := filepath.Join(homeDir, ".ssh", identityFile)
+			isSSH, err := helper.IsAvailableSSH(identifyPath)
+			if err != nil {
+				return err
+			}
+			if isSSH {
+				authProvider = helper.NewAuthProvider(helper.WithPemFile(identifyPath, password))
+			} else {
+				authProvider = helper.NewAuthProvider()
+			}
 		}
 
 		updateService := service.NewSync(authProvider, homeDir, pwd, pwd)
@@ -80,7 +84,7 @@ var upCmd = &cobra.Command{
 
 func initDepCmd() {
 	upCmd.PersistentFlags().BoolP("force", "f", false, "update locked file and .proto vendors")
-	upCmd.PersistentFlags().StringP("identity-file", "i", "id_rsa", "set the identity file for SSH")
+	upCmd.PersistentFlags().StringP("identity-file", "i", "", "set the identity file for SSH")
 	upCmd.PersistentFlags().StringP("password", "p", "", "set the password for SSH")
 	upCmd.PersistentFlags().BoolP("cleanup", "c", false, "cleanup cache before exec.")
 }

--- a/helper/auth_test.go
+++ b/helper/auth_test.go
@@ -13,6 +13,13 @@ func TestGetRepositoryURLWithSSH(t *testing.T) {
 	require.Equal(t, "ssh://github.com/stormcat24/protodep.git", actual)
 }
 
+func TestGetRepositoryURLWithSSHAgent(t *testing.T) {
+	target := &AuthProviderWithSSHAgent{}
+	actual := target.GetRepositoryURL("github.com/stormcat24/protodep")
+
+	require.Equal(t, "ssh://github.com/stormcat24/protodep.git", actual)
+}
+
 func TestGetRepositoryURLHTTPS(t *testing.T) {
 	target := &AuthProviderHTTPS{}
 	actual := target.GetRepositoryURL("github.com/stormcat24/protodep")


### PR DESCRIPTION
This addresses #43 

Because of the logic in the command line flags today, my implementation would be a breaking change for anyone who is relying on using `protodep`'s default behavior and using SSH key w/o a password. However, it is my belief that not using the ssh agent by default best meets the principle of least surprise. Most command line tools just use the SSH agent by default and you only need to override the behavior if you want to use a specific PEM.