### PR TITLE
Add a fallback message

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -98,11 +98,12 @@ var upCmd = &cobra.Command{
 				if isSSH {
 					authProvider = helper.NewAuthProvider(helper.WithPemFile(identifyPath, password))
 				} else {
+					logger.Warn("The identity file path has been passed but is not available. Falling back to ssh-agent, the default authentication method.")
 					authProvider = helper.NewAuthProvider()
 				}
 			}
 		}
-    
+
 		updateService := service.NewSync(authProvider, homeDir, pwd, pwd)
 		return updateService.Resolve(isForceUpdate, isCleanupCache)
 	},

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -12,6 +12,10 @@ func Info(format string, a ...interface{}) {
 	color.Green("[INFO] "+format, a...)
 }
 
+func Warn(format string, a ...interface{}) {
+	color.Yellow("[WARN] "+format, a...)
+}
+
 func Error(format string, a ...interface{}) {
 	color.Red("[ERROR] "+format, a...)
 }


### PR DESCRIPTION
Added a fallback message to inform the user that the identity file is not available.

```shell
$ protodep up -i foo
[INFO] force update = false
[INFO] cleanup cache = false
[INFO] identity file = foo
[INFO] use https = false
[WARN] The identity file path has been passed but is not available. Falling back to ssh-agent, the default authentication method.
```