### PR TITLE
Add subgroup option.

### DIFF
--- a/dependency/schema.go
+++ b/dependency/schema.go
@@ -21,7 +21,10 @@ type ProtoDepDependency struct {
 
 func (d *ProtoDepDependency) Repository() string {
 	tokens := strings.Split(d.Target, "/")
-	subgroupTokens := strings.Split(d.Subgroup, "/")
+	subgroupTokens := make([]string, 0)
+	if d.Subgroup != "" {
+		subgroupTokens = strings.Split(d.Subgroup, "/")
+	}
 	repoTokens := 3 + len(subgroupTokens)
 	if len(tokens) > repoTokens {
 		return strings.Join(tokens[0:repoTokens], "/")

--- a/dependency/schema.go
+++ b/dependency/schema.go
@@ -11,6 +11,7 @@ type ProtoDep struct {
 
 type ProtoDepDependency struct {
 	Target   string   `toml:"target"`
+	Subgroup string   `toml:"subgroup"`
 	Revision string   `toml:"revision"`
 	Branch   string   `toml:"branch"`
 	Path     string   `toml:"path"`
@@ -20,8 +21,10 @@ type ProtoDepDependency struct {
 
 func (d *ProtoDepDependency) Repository() string {
 	tokens := strings.Split(d.Target, "/")
-	if len(tokens) > 3 {
-		return strings.Join(tokens[0:3], "/")
+	subgroupTokens := strings.Split(d.Subgroup, "/")
+	repoTokens := 3 + len(subgroupTokens)
+	if len(tokens) > repoTokens {
+		return strings.Join(tokens[0:repoTokens], "/")
 	} else {
 		return d.Target
 	}

--- a/service/sync.go
+++ b/service/sync.go
@@ -143,6 +143,7 @@ func (s *SyncImpl) Resolve(forceUpdate bool, cleanupCache bool) error {
 			Path:     repo.Dep.Path,
 			Ignores:  repo.Dep.Ignores,
 			Protocol: repo.Dep.Protocol,
+			Subgroup: repo.Dep.Subgroup,
 		})
 	}
 


### PR DESCRIPTION
In GitLab it's possible to have subgroups to organize repositories. Protodep can not currently deal with this as it assumes the repo path follows GitHub rules and only contains `github.com/$organization/$repo`.

This commit adds a subgroup property to the dependency schema that allows the user to specify the subgroup or subgroups that are involved in the git URL reference. When the subgroup property is not present, the behavior remains unchanged so this should not be a breaking change.

As a concrete example consider this repo

https://gitlab.com/mergetb/portal/services

that has the structure `https://gitlab.com/$group/$subgroup/$repo`, in general arbitrary subgrouping on GitLab is possible 
 `https://gitlab.com/$gropup/$a/$b/$c/.../$repo`.

Thanks for the very useful tool!