### PR TITLE
Validate `proto_outdir` exists

### DIFF
--- a/dependency/dependency.go
+++ b/dependency/dependency.go
@@ -48,6 +48,11 @@ func (d *DependencyImpl) Load() (*ProtoDep, error) {
 	if _, err := toml.Decode(string(content), &conf); err != nil {
 		return nil, errors.Wrap(err, "decode toml is failed")
 	}
+
+	if err := conf.Validate(); err != nil {
+		return nil, errors.Wrap(err, "found invalid configuration")
+	}
+
 	return &conf, nil
 }
 

--- a/dependency/schema.go
+++ b/dependency/schema.go
@@ -2,11 +2,20 @@ package dependency
 
 import (
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type ProtoDep struct {
 	ProtoOutdir  string               `toml:"proto_outdir"`
 	Dependencies []ProtoDepDependency `toml:"dependencies"`
+}
+
+func (d *ProtoDep) Validate() error {
+	if strings.TrimSpace(d.ProtoOutdir) == "" {
+		return errors.New("'proto_outdir' is required")
+	}
+	return nil
 }
 
 type ProtoDepDependency struct {


### PR DESCRIPTION
This PR adds that validate `proto_outdir` is definitely existing in toml.

Here is the reason why I added:

- In the sync sequence, https://github.com/stormcat24/protodep/blob/master/service/sync.go#L76 removes all of the files under directly in `outdir`.
- If we didn't set `proto_outdir` in toml, all of the files under `s.conf.OutputDir` (=repository root, in most cases) will be removed.
- It's meaning of that there is a possibility we lose all files under the repository root.
- This PR is to avoid behavior like this before checking out the .proto files.