### PR TITLE
http auth on dependency level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,12 @@ _testmain.go
 *.test
 *.prof
 *.iml
+.envrc
 
 vendor/
 bin/
 .idea/
+.vscode/
 
 protodep.lock
 artifacts/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ protodep
 
 ![logo](./logo/web.png)
 
-
 ![GitHub Actions](https://github.com/stormcat24/protodep/actions/workflows/go.yml/badge.svg)
 [![Language](https://img.shields.io/badge/language-go-brightgreen.svg?style=flat)](https://golang.org/)
 [![issues](https://img.shields.io/github/issues/stormcat24/protodep.svg?style=flat)](https://github.com/stormcat24/protodep/issues?state=open)
@@ -13,20 +12,18 @@ protodep
 
 Dependency tool for Protocol Buffers IDL file (.proto) vendoring tool.
 
-
 ## Motivation
 
 In building Microservices architecture, gRPC with Protocol Buffers is effective. When using gRPC, your application will depend on many remote services.
 
 If you manage proto files in a git repository, what will you do? Most remote services are managed by git and they will be versioned. We need to control which dependency service version that application uses.
 
-
 ## Install
 
 ### go install
 
 ```bash
-$ go install -v github.com/stormcat24/protodep@v0.1.7
+go install -v github.com/stormcat24/protodep@v0.1.7
 ```
 
 ### from binary
@@ -41,9 +38,9 @@ Support as follows:
 * protodep_linux_arm64.tar.gz
 
 ```bash
-$ wget https://github.com/stormcat24/protodep/releases/download/0.1.4/protodep_darwin_amd64.tar.gz
-$ tar -xf protodep_darwin_amd64.tar.gz
-$ mv protodep /usr/local/bin/
+wget https://github.com/stormcat24/protodep/releases/download/0.1.4/protodep_darwin_amd64.tar.gz
+tar -xf protodep_darwin_amd64.tar.gz
+mv protodep /usr/local/bin/
 ```
 
 ## Usage
@@ -91,6 +88,11 @@ proto_outdir = "./proto"
   path = "service1"
   username_env = "GITLAB_USERNAME" # user environment variable for HTTP Basic Authentication
   password_env = "GITLAB_PASSWORD" # token/password environment variable for HTTP Basic Authentication
+
+# import from local folder
+[[dependencies]]
+local_folder = "./api/broker"
+path = "proto/broker"
 ```
 
 ### protodep up
@@ -98,7 +100,7 @@ proto_outdir = "./proto"
 In same directory, execute this command.
 
 ```bash
-$ protodep up
+protodep up
 ```
 
 If succeeded, `protodep.lock` is generated.
@@ -108,7 +110,7 @@ If succeeded, `protodep.lock` is generated.
 Even if protodep.lock exists, you can force update dependenies.
 
 ```bash
-$ protodep up -f
+protodep up -f
 ```
 
 ### [Attention] Changes from 0.1.0
@@ -119,8 +121,8 @@ In other words, in order to operate protodep without options as before, it is ne
 As the follows:
 
 ```bash
-$ ssh-add ~/.ssh/id_rsa
-$ protodep up
+ssh-add ~/.ssh/id_rsa
+protodep up
 ```
 
 ### Getting via HTTPS
@@ -128,11 +130,11 @@ $ protodep up
 If you want to get it via HTTPS, do as follows.
 
 ```bash
-$ protodep up --use-https
+protodep up --use-https
 ```
 
 And also, if Basic authentication is required, do as follows.
-If you have 2FA enabled, specify the Personal Access Token as the password. 
+If you have 2FA enabled, specify the Personal Access Token as the password.
 
 ```bash
 $ protodep up --use-https \
@@ -157,7 +159,6 @@ machine github.com
 login your-github-username
 password your-github-token
 ```
-
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ proto_outdir = "./proto"
     "**/fuga/**",
   ]
   protocol = "https"
+
+# gitlab subgroups
+# repository: gitlab.company.org/core/product/backend/service1
+# subgroup: backend/service
+[[dependencies]]
+  target = "gitlab.company.org/core/product/backend/service1/api/protos"
+  subgroup = "backend/service1"
+  revision = "v1.0.0"
+  path = "service1"
+  username_env = "GITLAB_USERNAME" # user environment variable for HTTP Basic Authentication
+  password_env = "GITLAB_PASSWORD" # token/password environment variable for HTTP Basic Authentication
 ```
 
 ### protodep up
@@ -128,6 +139,25 @@ $ protodep up --use-https \
     --basic-auth-username=your-github-username \
     --basic-auth-password=your-github-password
 ```
+
+You can also set the username and password as environment variables and set them in the protodep.toml file for each dependency.
+
+```toml
+[[dependencies]]
+  target = "github.com/your-org/your-repo"
+  branch = "master"
+  username_env = "GITHUB_USERNAME"
+  password_env = "GITHUB_PASSWORD"
+```
+
+Another way is to use the .netrc file in your home directory. Set the username and password in the .netrc as follows.
+
+```bash
+machine github.com
+login your-github-username
+password your-github-token
+```
+
 
 ### License
 

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -19,6 +19,7 @@ func (d *ProtoDep) Validate() error {
 
 type ProtoDepDependency struct {
 	Target      string   `toml:"target"`
+	LocalFolder string   `toml:"local_folder"`
 	Subgroup    string   `toml:"subgroup"`
 	Revision    string   `toml:"revision"`
 	Branch      string   `toml:"branch"`

--- a/pkg/config/schema.go
+++ b/pkg/config/schema.go
@@ -18,14 +18,16 @@ func (d *ProtoDep) Validate() error {
 }
 
 type ProtoDepDependency struct {
-	Target   string   `toml:"target"`
-	Subgroup string   `toml:"subgroup"`
-	Revision string   `toml:"revision"`
-	Branch   string   `toml:"branch"`
-	Path     string   `toml:"path"`
-	Ignores  []string `toml:"ignores"`
-	Includes []string `toml:"includes"`
-	Protocol string   `toml:"protocol"`
+	Target      string   `toml:"target"`
+	Subgroup    string   `toml:"subgroup"`
+	Revision    string   `toml:"revision"`
+	Branch      string   `toml:"branch"`
+	Path        string   `toml:"path"`
+	Ignores     []string `toml:"ignores"`
+	Includes    []string `toml:"includes"`
+	Protocol    string   `toml:"protocol"`
+	UsernameEnv string   `toml:"username_env"`
+	PasswordEnv string   `toml:"password_env"`
 }
 
 func (d *ProtoDepDependency) Repository() string {
@@ -50,4 +52,12 @@ func (d *ProtoDepDependency) Directory() string {
 	} else {
 		return "." + strings.Replace(d.Target, r, "", 1)
 	}
+}
+
+func (d *ProtoDepDependency) Machine() string {
+	tokens := strings.Split(d.Target, "/")
+	if len(tokens) < 1 {
+		return ""
+	}
+	return tokens[0]
 }

--- a/pkg/resolver/netrc.go
+++ b/pkg/resolver/netrc.go
@@ -1,0 +1,97 @@
+// based on https://go.dev/src/cmd/go/internal/auth/netrc.go
+
+package resolver
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type netrcLine struct {
+	machine  string
+	login    string
+	password string
+}
+
+func parseNetrc(data string) []netrcLine {
+	// See https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
+	// for documentation on the .netrc format.
+	var nrc []netrcLine
+	var l netrcLine
+	inMacro := false
+	for _, line := range strings.Split(data, "\n") {
+		if inMacro {
+			if line == "" {
+				inMacro = false
+			}
+			continue
+		}
+
+		f := strings.Fields(line)
+		i := 0
+		for ; i < len(f)-1; i += 2 {
+			// Reset at each "machine" token.
+			// “The auto-login process searches the .netrc file for a machine token
+			// that matches […]. Once a match is made, the subsequent .netrc tokens
+			// are processed, stopping when the end of file is reached or another
+			// machine or a default token is encountered.”
+			switch f[i] {
+			case "machine":
+				l = netrcLine{machine: f[i+1]}
+			case "default":
+				break
+			case "login":
+				l.login = f[i+1]
+			case "password":
+				l.password = f[i+1]
+			case "macdef":
+				// “A macro is defined with the specified name; its contents begin with
+				// the next .netrc line and continue until a null line (consecutive
+				// new-line characters) is encountered.”
+				inMacro = true
+			}
+			if l.machine != "" && l.login != "" && l.password != "" {
+				nrc = append(nrc, l)
+				l = netrcLine{}
+			}
+		}
+
+		if i < len(f) && f[i] == "default" {
+			// “There can be only one default token, and it must be after all machine tokens.”
+			break
+		}
+	}
+
+	return nrc
+}
+
+func netrcPath() (string, error) {
+	if env := os.Getenv("NETRC"); env != "" {
+		return env, nil
+	}
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	base := ".netrc"
+	if runtime.GOOS == "windows" {
+		base = "_netrc"
+	}
+	return filepath.Join(dir, base), nil
+}
+
+func readNetrc() ([]netrcLine, error) {
+	path, err := netrcPath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseNetrc(string(data)), nil
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -85,89 +85,37 @@ func (s *resolver) Resolve(forceUpdate bool, cleanupCache bool) error {
 	}
 
 	for _, dep := range protodep.Dependencies {
-		var (
-			authProvider           auth.AuthProvider
-			userName, userPassword string
-		)
+		var sources []protoResource
 
-		if dep.PasswordEnv != "" || dep.UsernameEnv != "" {
-			if dep.UsernameEnv == "" || dep.PasswordEnv == "" {
-				return fmt.Errorf("auth_username_env and auth_password_env must be set together")
-			}
-
-			userName = os.Getenv(dep.UsernameEnv)
-			userPassword = os.Getenv(dep.PasswordEnv)
-
-			if userName == "" {
-				return fmt.Errorf("auth_username_env %s is empty", dep.UsernameEnv)
-			}
-
-			if userPassword == "" {
-				return fmt.Errorf("auth_password_env %s is empty", dep.PasswordEnv)
-			}
-		} else {
-			machine := dep.Machine()
-
-			for _, netrc := range netrcInfo {
-				if netrc.machine == machine && netrc.login != "" && netrc.password != "" {
-					userName = netrc.login
-					userPassword = netrc.password
-					break
-				}
-			}
+		if dep.Target != "" && dep.LocalFolder != "" {
+			return fmt.Errorf("target and local_folder cannot be set together")
 		}
 
-		if s.conf.UseHttps || dep.Protocol == "https" || (dep.Protocol == "" && userName != "") {
-			if userName != "" {
-				authProvider = auth.NewAuthProvider(auth.WithHTTPS(userName, userPassword))
-			} else {
-				authProvider = s.httpsProvider
+		if dep.LocalFolder != "" {
+			if dep.Subgroup != "" || dep.Revision != "" || dep.Branch != "" ||
+				dep.Protocol != "" || dep.UsernameEnv != "" || dep.PasswordEnv != "" {
+				return fmt.Errorf("subgroup, revision, branch, path, protocol and username_env cannot be set together with local_folder")
 			}
-		} else {
-			if dep.Protocol == "ssh" {
-				if dep.UsernameEnv != "" {
-					return fmt.Errorf("auth_username_env and auth_password_env are not supported for ssh protocol")
-				}
-				authProvider = s.sshProvider
-			}
-		}
 
-		gitrepo := repository.NewGit(protodepDir, dep, authProvider)
-
-		repo, err := gitrepo.Open()
-		if err != nil {
-			return err
-		}
-
-		sources := make([]protoResource, 0)
-
-		compiledIgnores := compileIgnoreToGlob(dep.Ignores)
-		compiledIncludes := compileIgnoreToGlob(dep.Includes)
-
-		hasIncludes := len(dep.Includes) > 0
-
-		protoRootDir := gitrepo.ProtoRootDir()
-		filepath.Walk(protoRootDir, func(path string, info os.FileInfo, err error) error {
+			sources, err = s.getSources(dep, dep.LocalFolder)
 			if err != nil {
 				return err
 			}
-			if strings.HasSuffix(path, ".proto") {
-				isIncludePath := s.isMatchPath(protoRootDir, path, dep.Includes, compiledIncludes)
-				isIgnorePath := s.isMatchPath(protoRootDir, path, dep.Ignores, compiledIgnores)
-
-				if hasIncludes && !isIncludePath {
-					logger.Info("skipped %s due to include setting", path)
-				} else if isIgnorePath {
-					logger.Info("skipped %s due to ignore setting", path)
-				} else {
-					sources = append(sources, protoResource{
-						source:       path,
-						relativeDest: strings.Replace(path, protoRootDir, "", -1),
-					})
-				}
+		} else if dep.Target != "" {
+			gitrepo, err := s.getRepository(dep, protodepDir, netrcInfo)
+			if err != nil {
+				return err
 			}
-			return nil
-		})
+			if _, err = gitrepo.Open(); err != nil {
+				return err
+			}
+			sources, err = s.getSources(dep, gitrepo.ProtoRootDir())
+			if err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("target or local_folder must be set")
+		}
 
 		for _, s := range sources {
 			outpath := filepath.Join(outdir, dep.Path, s.relativeDest)
@@ -182,16 +130,7 @@ func (s *resolver) Resolve(forceUpdate bool, cleanupCache bool) error {
 			}
 		}
 
-		newdeps = append(newdeps, config.ProtoDepDependency{
-			Target:   repo.Dep.Target,
-			Branch:   repo.Dep.Branch,
-			Revision: repo.Hash,
-			Path:     repo.Dep.Path,
-			Includes: repo.Dep.Includes,
-			Ignores:  repo.Dep.Ignores,
-			Protocol: repo.Dep.Protocol,
-			Subgroup: repo.Dep.Subgroup,
-		})
+		newdeps = append(newdeps, dep)
 	}
 
 	newProtodep := config.ProtoDep{
@@ -206,6 +145,93 @@ func (s *resolver) Resolve(forceUpdate bool, cleanupCache bool) error {
 	}
 
 	return nil
+}
+
+func (s *resolver) getRepository(dep config.ProtoDepDependency, protodepDir string, netrcInfo []netrcLine) (repository.Git, error) {
+	var (
+		authProvider           auth.AuthProvider
+		userName, userPassword string
+	)
+
+	if dep.PasswordEnv != "" || dep.UsernameEnv != "" {
+		if dep.UsernameEnv == "" || dep.PasswordEnv == "" {
+			return nil, fmt.Errorf("auth_username_env and auth_password_env must be set together")
+		}
+
+		userName = os.Getenv(dep.UsernameEnv)
+		userPassword = os.Getenv(dep.PasswordEnv)
+
+		if userName == "" {
+			return nil, fmt.Errorf("auth_username_env %s is empty", dep.UsernameEnv)
+		}
+
+		if userPassword == "" {
+			return nil, fmt.Errorf("auth_password_env %s is empty", dep.PasswordEnv)
+		}
+	} else {
+		machine := dep.Machine()
+
+		for _, netrc := range netrcInfo {
+			if netrc.machine == machine && netrc.login != "" && netrc.password != "" {
+				userName = netrc.login
+				userPassword = netrc.password
+				break
+			}
+		}
+	}
+
+	if s.conf.UseHttps || dep.Protocol == "https" || (dep.Protocol == "" && userName != "") {
+		if userName != "" {
+			authProvider = auth.NewAuthProvider(auth.WithHTTPS(userName, userPassword))
+		} else {
+			authProvider = s.httpsProvider
+		}
+	} else {
+		if dep.Protocol == "ssh" {
+			if dep.UsernameEnv != "" {
+				return nil, fmt.Errorf("auth_username_env and auth_password_env are not supported for ssh protocol")
+			}
+			authProvider = s.sshProvider
+		}
+	}
+
+	return repository.NewGit(protodepDir, dep, authProvider), nil
+}
+
+func (s *resolver) getSources(dep config.ProtoDepDependency, protoRootDir string) ([]protoResource, error) {
+	sources := make([]protoResource, 0)
+
+	compiledIgnores := compileIgnoreToGlob(dep.Ignores)
+	compiledIncludes := compileIgnoreToGlob(dep.Includes)
+
+	hasIncludes := len(dep.Includes) > 0
+
+	err := filepath.Walk(protoRootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(path, ".proto") {
+			isIncludePath := s.isMatchPath(protoRootDir, path, dep.Includes, compiledIncludes)
+			isIgnorePath := s.isMatchPath(protoRootDir, path, dep.Ignores, compiledIgnores)
+
+			if hasIncludes && !isIncludePath {
+				logger.Info("skipped %s due to include setting", path)
+			} else if isIgnorePath {
+				logger.Info("skipped %s due to ignore setting", path)
+			} else {
+				sources = append(sources, protoResource{
+					source:       path,
+					relativeDest: strings.Replace(path, protoRootDir, "", -1),
+				})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return sources, nil
 }
 
 func (s *resolver) SetHttpsAuthProvider(provider auth.AuthProvider) {

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -80,7 +80,7 @@ func (s *resolver) Resolve(forceUpdate bool, cleanupCache bool) error {
 
 	var netrcInfo []netrcLine
 	netrcInfo, err = readNetrc()
-	if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
 		logger.Warn("netrc file error: %v", err)
 	}
 
@@ -97,7 +97,12 @@ func (s *resolver) Resolve(forceUpdate bool, cleanupCache bool) error {
 				return fmt.Errorf("subgroup, revision, branch, path, protocol and username_env cannot be set together with local_folder")
 			}
 
-			sources, err = s.getSources(dep, dep.LocalFolder)
+			localFolder, err := filepath.Abs(dep.LocalFolder)
+			if err != nil {
+				return fmt.Errorf("invalid local_folder: %w", err)
+			}
+
+			sources, err = s.getSources(dep, localFolder)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- I use protodep to work with dependencies from public and private repositories at the same time. In such a situation, the global setup of basic-auth-username and basic-auth-password via the command line is not suitable. 
Added the ability to set a username and password at the level of each dependency in protodep.toml.
- Added the ability to import from local folders. This can be useful if we need to collect all protos (including local ones) in one place for the import to work correctly.

P.S. The changes in 0644 are the go autoformat, not my edits